### PR TITLE
fix: rename title styles in teachers section

### DIFF
--- a/src/partials/teachers.html
+++ b/src/partials/teachers.html
@@ -1,10 +1,10 @@
 <section id="teachers" class="teachers section">
   <div class="container">
     <h2 class="visually-hidden">Teachers</h2>
-    <p class="section_title">
-      Meet our <span class="section_title_span">teachers</span>
+    <p class="section__title">
+      Meet our <span class="section__title--span">teachers</span>
     </p>
-    <p class="section_subtitle">
+    <p class="section__subtitle">
       Discover our team of dedicated educators, committed to guiding you on your
       journey to English proficiency with personalized and engaging instruction
     </p>


### PR DESCRIPTION
Виправлено назви класів згідно з файлом title.css